### PR TITLE
Implement basic Account CRUD: entity, repository, service, and contro…

### DIFF
--- a/backend/account-service/build.gradle
+++ b/backend/account-service/build.gradle
@@ -19,6 +19,14 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	//JPA
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	//H2
+	implementation 'com.h2database:h2'
+	// Lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+	//Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/backend/account-service/src/main/java/com/fintrack/account/controller/AccountController.java
+++ b/backend/account-service/src/main/java/com/fintrack/account/controller/AccountController.java
@@ -1,17 +1,47 @@
 package com.fintrack.account.controller;
 
+import com.fintrack.account.entity.AccountEntity;
+import com.fintrack.account.service.AccountService;
 import org.springframework.web.bind.annotation.*;
-import java.util.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/accounts")
 public class AccountController {
 
+    private final AccountService service;
+
+    public AccountController(AccountService service) {
+        this.service = service;
+    }
+
     @GetMapping
-    public List<Map<String, String>> getAllAccounts() {
-        return List.of(
-                Map.of("id", "1", "name", "Cash"),
-                Map.of("id", "2", "name", "Receivables")
-        );
+    public List<AccountEntity> getAll() {
+        return service.findAll();
+    }
+
+    @PostMapping
+    public AccountEntity create(@RequestBody AccountEntity account) {
+        return service.create(account);
     }
 }
+
+//========================================================================================================
+//package com.fintrack.account.controller;
+//
+//import org.springframework.web.bind.annotation.*;
+//import java.util.*;
+//
+//@RestController
+//@RequestMapping("/api/accounts")
+//public class AccountController {
+//
+//    @GetMapping
+//    public List<Map<String, String>> getAllAccounts() {
+//        return List.of(
+//                Map.of("id", "1", "name", "Cash"),
+//                Map.of("id", "2", "name", "Receivables")
+//        );
+//    }
+//}

--- a/backend/account-service/src/main/java/com/fintrack/account/entity/AccountEntity.java
+++ b/backend/account-service/src/main/java/com/fintrack/account/entity/AccountEntity.java
@@ -1,0 +1,28 @@
+package com.fintrack.account.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Entity
+@Data
+public class AccountEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String code;
+
+    @Column(nullable = false)
+    private String type; // ex: ASSET, LIABILITY...
+
+    @Column
+    private UUID parentId;
+
+    // Getters and Setters
+}

--- a/backend/account-service/src/main/java/com/fintrack/account/repository/AccountRepository.java
+++ b/backend/account-service/src/main/java/com/fintrack/account/repository/AccountRepository.java
@@ -1,0 +1,9 @@
+package com.fintrack.account.repository;
+
+import com.fintrack.account.entity.AccountEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface AccountRepository extends JpaRepository<AccountEntity, UUID> {
+}

--- a/backend/account-service/src/main/java/com/fintrack/account/service/AccountService.java
+++ b/backend/account-service/src/main/java/com/fintrack/account/service/AccountService.java
@@ -1,0 +1,27 @@
+package com.fintrack.account.service;
+
+import com.fintrack.account.entity.AccountEntity;
+import com.fintrack.account.repository.AccountRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class AccountService {
+
+    private final AccountRepository repository;
+
+    public AccountService(AccountRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<AccountEntity> findAll() {
+        return repository.findAll();
+    }
+
+    public AccountEntity create(AccountEntity account) {
+        account.setId(UUID.randomUUID());
+        return repository.save(account);
+    }
+}

--- a/backend/account-service/src/main/resources/application.properties
+++ b/backend/account-service/src/main/resources/application.properties
@@ -1,1 +1,14 @@
 spring.application.name=account-service
+# H2 database config
+spring.datasource.url=jdbc:h2:mem:fintrackdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# JPA config
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update
+spring.h2.console.enabled=true
+
+# Console web do H2 (acessível em http://localhost:8080/h2-console)
+spring.h2.console.path=/h2-console


### PR DESCRIPTION
This PR introduces the initial CRUD functionality for the Account resource.

✅ Includes:
- Account entity
- JPA repository
- AccountService with basic business logic
- AccountController with standard REST endpoints
- Basic config in `application.properties`

Next steps:
- Add validations
- Implement DTO mapping
- Write unit/integration tests

